### PR TITLE
Include bsconfig.json in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0-2",
   "author": "Phil Pluckthun <phil@kitten.sh>",
   "files": [
+    "bsconfig.json",
     "dist",
     "src",
     "lib/es6",


### PR DESCRIPTION
Without this, users of the package will get an error saying the package wonka not found or built. Should fix #2 