### PR TITLE
Add tests for WonkaJs timing functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "terser:cjs": "terser --config-file .terser.config.json -o ./dist/wonka.js ./dist/wonka.js",
     "terser": "run-p terser:es terser:cjs",
     "prettier": "prettier --write ./dist/*.js",
-    "refmt": "bsrefmt --in-place **/**/*.re",
+    "refmt": "bsrefmt --in-place **/**/*.{re,rei}",
     "prebundle": "rimraf ./dist",
     "bundle": "microbundle --external none --no-compress --no-sourcemap --format es,cjs",
     "postbundle": "run-s terser prettier",
@@ -65,7 +65,7 @@
     "terser": "^3.14.1"
   },
   "lint-staged": {
-    "*.re": [
+    "*.{re, rei}": [
       "bsrefmt --in-place",
       "git add"
     ]

--- a/src/operators/wonka_operator_concatMap.rei
+++ b/src/operators/wonka_operator_concatMap.rei
@@ -1,5 +1,5 @@
 open Wonka_types;
 
-let concatMap: ((.'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
+let concatMap: ((. 'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
 let concat: (array(sourceT('a)), sinkT('a)) => unit;
 let concatAll: (sourceT(sourceT('a)), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_filter.rei
+++ b/src/operators/wonka_operator_filter.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let filter: ((.'a) => bool, sourceT('a), sinkT('a)) => unit;
+let filter: ((. 'a) => bool, sourceT('a), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_map.rei
+++ b/src/operators/wonka_operator_map.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let map: ((.'a) => 'b, sourceT('a), sinkT('b)) => unit;
+let map: ((. 'a) => 'b, sourceT('a), sinkT('b)) => unit;

--- a/src/operators/wonka_operator_mergeMap.rei
+++ b/src/operators/wonka_operator_mergeMap.rei
@@ -1,6 +1,6 @@
 open Wonka_types;
 
-let mergeMap: ((.'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
+let mergeMap: ((. 'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
 let merge: (array(sourceT('a)), sinkT('a)) => unit;
 let mergeAll: (sourceT(sourceT('a)), sinkT('a)) => unit;
 let flatten: (sourceT(sourceT('a)), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_onEnd.rei
+++ b/src/operators/wonka_operator_onEnd.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let onEnd: ((.unit) => unit, sourceT('a), sinkT('a)) => unit;
+let onEnd: ((. unit) => unit, sourceT('a), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_onPush.rei
+++ b/src/operators/wonka_operator_onPush.rei
@@ -1,4 +1,4 @@
 open Wonka_types;
 
-let onPush: ((.'a) => unit, sourceT('a), sinkT('a)) => unit;
-let tap: ((.'a) => unit, sourceT('a), sinkT('a)) => unit;
+let onPush: ((. 'a) => unit, sourceT('a), sinkT('a)) => unit;
+let tap: ((. 'a) => unit, sourceT('a), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_onStart.rei
+++ b/src/operators/wonka_operator_onStart.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let onStart: ((.unit) => unit, sourceT('a), sinkT('a)) => unit;
+let onStart: ((. unit) => unit, sourceT('a), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_scan.rei
+++ b/src/operators/wonka_operator_scan.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let scan: ((.'b, 'a) => 'b, 'b, sourceT('a), sinkT('b)) => unit;
+let scan: ((. 'b, 'a) => 'b, 'b, sourceT('a), sinkT('b)) => unit;

--- a/src/operators/wonka_operator_skipWhile.rei
+++ b/src/operators/wonka_operator_skipWhile.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let skipWhile: ((.'a) => bool, sourceT('a), sinkT('a)) => unit;
+let skipWhile: ((. 'a) => bool, sourceT('a), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_switchMap.rei
+++ b/src/operators/wonka_operator_switchMap.rei
@@ -1,4 +1,4 @@
 open Wonka_types;
 
-let switchMap: ((.'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
+let switchMap: ((. 'a) => sourceT('b), sourceT('a), sinkT('b)) => unit;
 let switchAll: (sourceT(sourceT('a)), sinkT('a)) => unit;

--- a/src/operators/wonka_operator_takeWhile.rei
+++ b/src/operators/wonka_operator_takeWhile.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let takeWhile: ((.'a) => bool, sourceT('a), sinkT('a)) => unit;
+let takeWhile: ((. 'a) => bool, sourceT('a), sinkT('a)) => unit;

--- a/src/sinks/wonka_sink_subscribe.rei
+++ b/src/sinks/wonka_sink_subscribe.rei
@@ -1,4 +1,4 @@
 open Wonka_types;
 
-let subscribe: ((.'a) => unit, sourceT('a)) => subscriptionT;
-let forEach: ((.'a) => unit, sourceT('a)) => unit;
+let subscribe: ((. 'a) => unit, sourceT('a)) => subscriptionT;
+let forEach: ((. 'a) => unit, sourceT('a)) => unit;

--- a/src/sources/wonka_source_make.rei
+++ b/src/sources/wonka_source_make.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let make: ((.observerT('a)) => teardownT, sinkT('a)) => unit;
+let make: ((. observerT('a)) => teardownT, sinkT('a)) => unit;

--- a/src/sources/wonka_source_primitives.rei
+++ b/src/sources/wonka_source_primitives.rei
@@ -1,4 +1,4 @@
 open Wonka_types;
 
-let empty: (sinkT('a)) => unit;
-let never: (sinkT('a)) => unit;
+let empty: sinkT('a) => unit;
+let never: sinkT('a) => unit;

--- a/src/web/wonka_operator_debounce.rei
+++ b/src/web/wonka_operator_debounce.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let debounce: ((.'a) => int, sourceT('a), sinkT('a)) => unit;
+let debounce: ((. 'a) => int, sourceT('a), sinkT('a)) => unit;

--- a/src/web/wonka_operator_throttle.rei
+++ b/src/web/wonka_operator_throttle.rei
@@ -1,3 +1,3 @@
 open Wonka_types;
 
-let throttle: ((.'a) => int, sourceT('a), sinkT('a)) => unit;
+let throttle: ((. 'a) => int, sourceT('a), sinkT('a)) => unit;

--- a/src/web/wonka_source_fromListener.rei
+++ b/src/web/wonka_source_fromListener.rei
@@ -1,8 +1,4 @@
 open Wonka_types;
 
 let fromListener:
-  (
-    ('event => unit) => unit,
-    ('event => unit) => unit,
-    sinkT('event)
-  ) => unit;
+  (('event => unit) => unit, ('event => unit) => unit, sinkT('event)) => unit;


### PR DESCRIPTION
This PR adds tests for some of the timing operators included in the `WonkaJs` module, specifically `delay`, `throttle`, `debounce`, and `sample`. Just chipping away at test coverage and having fun learning more `wonka` / observable-based programming 😅.

It also adds `*.rei` files to our pre-commit hook and `yarn refmt` script, which I missed in #15 😞.   