### PR TITLE
Add basic tests cases for toPromise.

### DIFF
--- a/__tests__/wonka_test.re
+++ b/__tests__/wonka_test.re
@@ -1945,4 +1945,25 @@ describe("web operators", () => {
       expect(signals) == [|Push(1), Push(3), Push(5), End|];
     });
   });
+
+  describe("toPromise", () => {
+    open Expect;
+    open! Expect.Operators;
+
+    testPromise("should convert a source to a Promise", () => {
+      let a = Wonka.fromValue(1);
+
+      a
+      |> WonkaJs.toPromise
+      |> Js.Promise.then_(x => expect(x) |> toEqual(1) |> Js.Promise.resolve);
+    });
+
+    testPromise("should resolve only the last emitted value from a source", () => {
+      let a = Wonka.fromList([1, 2, 3]);
+
+      a
+      |> WonkaJs.toPromise
+      |> Js.Promise.then_(x => expect(x) |> toEqual(3) |> Js.Promise.resolve);
+    });
+  });
 });


### PR DESCRIPTION
A very smol PR to verify the behavior of `toPromise` with basic sources (i.e. `fromValue` and `fromList`). @kitten I don't think I'm quite hitting the behavior we are over on `urql` with `client.executeQuery`, but I at least wanted to get this going to verify that `toPromise` is indeed resolving values. 