### PR TITLE
Remove namespacing from bsconfig.json. Update version in bsconfig.json.

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,6 @@
 {
   "name": "wonka",
-  "namespace": true,
-  "version": "0.1.0",
+  "version": "3.0.0",
   "bsc-flags": ["-bs-super-errors", "-bs-no-version-header"],
   "refmt": 3,
   "package-specs": [
@@ -49,8 +48,6 @@
       "type": "dev"
     }
   ],
-  "bs-dependencies" : [],
-  "bs-dev-dependencies": [
-    "@glennsl/bs-jest"
-  ]
+  "bs-dependencies": [],
+  "bs-dev-dependencies": ["@glennsl/bs-jest"]
 }


### PR DESCRIPTION
Fixes #25. 

With the addition of `namespace: true` in v3, BuckleScript automatically namespaced our `Wonka` under the `Wonka` namespace. This meant that, in order to reference functions from the library in Reason, you'd have to do one of the following.

1. `open` Wonka and then use `Wonka.` for access.

```reason
open Wonka;

let source = Wonka.fromArray([|1, 2, 3|]);
```

or 2. `open Wonka.Wonka`

```reason
open Wonka.Wonka;

let source = fromArray([|1, 2, 3|]);
```

Since the module structure we use already implements namespacing manually via `wonka.ml`, we can safely remove the `namespace` field from `bsconfig.json`. This may necessitate a minor version bump since it would be a breaking change for people currently hacking around this with one of the above solutions.