### PR TITLE
Fix takeWhile emitting two Start signals

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -929,19 +929,5 @@ let takeWhile = (f: (. 'a) => bool): operatorT('a, 'a) =>
         | Push(_) => ()
         }
       );
-
-      sink(.
-        Start(
-          (. signal) =>
-            if (! ended^) {
-              switch (signal) {
-              | Pull => talkback^(. Pull)
-              | Close =>
-                ended := true;
-                talkback^(. Close);
-              };
-            },
-        ),
-      );
     })
   );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -902,27 +902,34 @@ let takeUntil = (notifier: sourceT('a)): operatorT('b, 'b) =>
     })
   );
 
+type takeWhileStateT = {
+  mutable talkback: (. talkbackT) => unit,
+  mutable ended: bool,
+};
+
 [@genType]
 let takeWhile = (f: (. 'a) => bool): operatorT('a, 'a) =>
   curry(source =>
     curry(sink => {
-      let ended = ref(false);
-      let talkback = ref(talkbackPlaceholder);
+      let state: takeWhileStateT = {
+        talkback: talkbackPlaceholder,
+        ended: false,
+      };
 
       source((. signal) =>
         switch (signal) {
         | Start(tb) =>
-          talkback := tb;
+          state.talkback = tb;
           sink(. signal);
-        | End when ! ended^ =>
-          ended := true;
+        | End when !state.ended =>
+          state.ended = true;
           sink(. End);
         | End => ()
-        | Push(x) when ! ended^ =>
+        | Push(x) when !state.ended =>
           if (!f(. x)) {
-            ended := true;
+            state.ended = true;
             sink(. End);
-            talkback^(. Close);
+            state.talkback(. Close);
           } else {
             sink(. signal);
           }

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -916,7 +916,7 @@ describe('takeWhile', () => {
   passesActivePush(noop);
   passesSinkClose(noop);
   passesSourceEnd(noop);
-  // TODO: passesSingleStart(noop);
+  passesSingleStart(noop);
   passesStrictEnd(noop);
   passesAsyncSequence(noop);
 
@@ -931,9 +931,7 @@ describe('takeWhile', () => {
     next(1);
     next(2);
 
-    expect(fn).toHaveBeenCalledTimes(4);
     expect(fn.mock.calls).toEqual([
-      [deriving.start(expect.any(Function))],
       [deriving.start(expect.any(Function))],
       [deriving.push(1)],
       [deriving.end()],


### PR DESCRIPTION
The `takeWhile` operator has a small bug that causes it to emit two `Start` signals.

One option to fix this was to keep the `sink(. Start` wrapper and remove the forwarding of the `Start` signal from the parent source, but removing it seems to still pass all compliance tests, which means that it's also just safe to remove it and save some bytes 🌶 