### PR TITLE
Fix take operator not supporting take(0) and not respecting Close

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -795,7 +795,7 @@ let take = (max: int): operatorT('a, 'a) =>
           sink(. End);
           tb(. Close);
         | Start(tb) => state.talkback = tb
-        | Push(_) when state.taken < max =>
+        | Push(_) when state.taken < max && !state.ended =>
           state.taken = state.taken + 1;
           sink(. signal);
           if (!state.ended && state.taken >= max) {

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -785,6 +785,9 @@ let take = (max: int): operatorT('a, 'a) =>
 
       source((. signal) =>
         switch (signal) {
+        | Start(tb) when max <= 0 =>
+          sink(. End);
+          tb(. Close);
         | Start(tb) => state.talkback = tb
         | Push(_) when state.taken < max =>
           state.taken = state.taken + 1;

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -208,7 +208,7 @@ const passesStrictEnd = (operator: types.operatorT<any, any>) =>
         if (tb === deriving.pull) {
           pulls++;
           sink(deriving.end());
-          sink(deriving.push(0));
+          sink(deriving.push(123));
         }
       }));
     };
@@ -851,7 +851,7 @@ describe('take', () => {
   const noop = operators.take(10);
   passesPassivePull(noop);
   passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
+  passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -857,9 +857,7 @@ describe('take', () => {
   passesStrictEnd(noop);
   passesAsyncSequence(noop);
 
-  // TODO: take(0) seems to be broken
-  const ending = operators.take(1);
-  passesCloseAndEnd(ending);
+  passesCloseAndEnd(operators.take(0));
 
   it('emits values until a maximum is reached', () => {
     const { source, next } = sources.makeSubject<number>();


### PR DESCRIPTION
Fix cases where `take` is called with `<= 0` as the `max` number.

Also fix the `passesSinkClose` case where after `take` has ended, an `End` signal would still be forwarded due to some confusion with `state.taken`