### PR TITLE
Fix passesSinkClose for delay operator

### DIFF
--- a/src/web/wonkaJs.re
+++ b/src/web/wonkaJs.re
@@ -71,7 +71,7 @@ let debounce = (f: (. 'a) => int): operatorT('a, 'a) =>
 type delayStateT = {
   mutable talkback: (. talkbackT) => unit,
   mutable active: int,
-  mutable gotEndSignal: bool,
+  mutable ended: bool,
 };
 
 [@genType]
@@ -81,25 +81,21 @@ let delay = (wait: int): operatorT('a, 'a) =>
       let state: delayStateT = {
         talkback: Wonka_helpers.talkbackPlaceholder,
         active: 0,
-        gotEndSignal: false,
+        ended: false,
       };
 
       source((. signal) =>
         switch (signal) {
         | Start(tb) => state.talkback = tb
-        | _ when !state.gotEndSignal =>
+        | _ when !state.ended =>
           state.active = state.active + 1;
           ignore(
             Js.Global.setTimeout(
-              () => {
-                if (state.gotEndSignal && state.active === 0) {
-                  sink(. End);
-                } else {
+              () =>
+                if (!state.ended || state.active !== 0) {
                   state.active = state.active - 1;
-                };
-
-                sink(. signal);
-              },
+                  sink(. signal);
+                },
               wait,
             ),
           );
@@ -111,13 +107,11 @@ let delay = (wait: int): operatorT('a, 'a) =>
         Start(
           (. signal) =>
             switch (signal) {
-            | Close =>
-              state.gotEndSignal = true;
-              if (state.active === 0) {
-                sink(. End);
-              };
-            | _ when !state.gotEndSignal => state.talkback(. signal)
-            | _ => ()
+            | Close when !state.ended =>
+              state.ended = true;
+              state.talkback(. Close);
+            | Pull when !state.ended => state.talkback(. Pull)
+            | Pull => ()
             },
         ),
       );

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -456,7 +456,7 @@ describe('delay', () => {
   const noop = web.delay(0);
   passesPassivePull(noop);
   passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
+  passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
   passesAsyncSequence(noop);


### PR DESCRIPTION
This fixes the delay operator by removing an unnecessary
End event being sent when Close is received.
It also fixes a potential duplicate End signal and renames
`gotEndSignal` to `ended`.