### PR TITLE
Fix debounce emitting End after Close signal

### DIFF
--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -450,6 +450,18 @@ describe('debounce', () => {
     jest.advanceTimersByTime(1);
     expect(fn).toHaveBeenCalledWith(2);
   });
+
+  it('emits debounced value with delayed End signal', () => {
+    const { source, next, complete } = sources.makeSubject<number>();
+    const fn = jest.fn();
+
+    sinks.forEach(fn)(web.debounce(() => 100)(source));
+
+    next(1);
+    complete();
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalled();
+  });
 });
 
 describe('delay', () => {

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -430,7 +430,7 @@ describe('debounce', () => {
   passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
-  // TODO: passesStrictEnd(noop);
+  passesStrictEnd(noop);
   passesAsyncSequence(noop);
 
   it('waits for a specified amount of silence before emitting the last value', () => {


### PR DESCRIPTION
Since there was no difference between `End` and `Close` in the `debounce` operator, after the timeout completed it would emit an `End` event even if the source has received `Close`. This was because in the `Push` timeout it just checks `state.ended` (or previously `gotEndSignal^`), which would also be set to `true` by `Close`.

This also adds a test to verify that the `End` signal comes in delayed after the debounce completes.