### PR TITLE
Fix cold sources for {concat,switch,merge}Map

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -161,7 +161,6 @@ type concatMapStateT('a) = {
   mutable innerTalkback: (. talkbackT) => unit,
   mutable innerActive: bool,
   mutable innerPulled: bool,
-  mutable closed: bool,
   mutable ended: bool,
 };
 
@@ -176,7 +175,6 @@ let concatMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         innerTalkback: talkbackPlaceholder,
         innerActive: false,
         innerPulled: false,
-        closed: false,
         ended: false,
       };
 
@@ -249,11 +247,10 @@ let concatMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
               };
             | Close when !state.ended =>
               state.ended = true;
-              state.closed = true;
               state.innerActive = false;
               state.innerTalkback(. Close);
               state.outerTalkback(. Close);
-            | Pull => ()
+            | Close => ()
             },
         ),
       );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -744,6 +744,7 @@ let switchMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
           };
 
           if (!state.outerPulled) {
+            state.outerPulled = true;
             state.outerTalkback(. Pull);
           } else {
             state.outerPulled = false;

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -345,12 +345,10 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
           (. signal) =>
             switch (signal) {
             | Close when !state.ended =>
-              state.ended = true;
-              state.outerTalkback(. Close);
-              Rebel.Array.forEach(state.innerTalkbacks, talkback =>
-                talkback(. Close)
-              );
+              let tbs = state.innerTalkbacks;
               state.innerTalkbacks = Rebel.Array.makeEmpty();
+              state.outerTalkback(. signal);
+              Rebel.Array.forEach(tbs, tb => tb(. signal));
             | Close => ()
             | Pull when !state.ended =>
               if (!state.outerPulled) {

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -523,7 +523,7 @@ describe('mergeMap', () => {
   const noop = operators.mergeMap(x => sources.fromValue(x));
   passesPassivePull(noop);
   passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
+  passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -366,10 +366,10 @@ describe('buffer', () => {
 
 describe('concatMap', () => {
   const noop = operators.concatMap(x => sources.fromValue(x));
-  // TODO: passesPassivePull(noop);
-  // TODO: passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
-  // TODO: passesSourceEnd(noop);
+  passesPassivePull(noop);
+  passesActivePush(noop);
+  passesSinkClose(noop);
+  passesSourceEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);
   passesAsyncSequence(noop);
@@ -420,6 +420,19 @@ describe('concatMap', () => {
       [10],
       [20],
     ]);
+  });
+
+  it('emits synchronous values in order', () => {
+    const values = [];
+
+    sinks.forEach(x => values.push(x))(
+      operators.concat([
+        sources.fromArray([1, 2]),
+        sources.fromArray([3, 4])
+      ])
+    );
+
+    expect(values).toEqual([ 1, 2, 3, 4 ]);
   });
 });
 

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -521,10 +521,10 @@ describe('map', () => {
 
 describe('mergeMap', () => {
   const noop = operators.mergeMap(x => sources.fromValue(x));
-  // TODO: passesPassivePull(noop);
-  // TODO: passesActivePush(noop);
+  passesPassivePull(noop);
+  passesActivePush(noop);
   // TODO: passesSinkClose(noop);
-  // TODO: passesSourceEnd(noop);
+  passesSourceEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);
   passesAsyncSequence(noop);
@@ -562,13 +562,26 @@ describe('mergeMap', () => {
       })(source)
     );
 
-    jest.advanceTimersByTime(14);
+    jest.runAllTimers();
     expect(fn.mock.calls).toEqual([
       [1],
-      [10],
       [2],
+      [10],
       [20],
     ]);
+  });
+
+  it('emits synchronous values in order', () => {
+    const values = [];
+
+    sinks.forEach(x => values.push(x))(
+      operators.merge([
+        sources.fromArray([1, 2]),
+        sources.fromArray([3, 4])
+      ])
+    );
+
+    expect(values).toEqual([ 1, 2, 3, 4 ]);
   });
 });
 

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -797,10 +797,10 @@ describe('skipWhile', () => {
 
 describe('switchMap', () => {
   const noop = operators.switchMap(x => sources.fromValue(x));
-  // TODO: passesPassivePull(noop);
+  passesPassivePull(noop);
   // TODO: passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
-  // TODO: passesSourceEnd(noop);
+  passesSinkClose(noop);
+  passesSourceEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);
   passesAsyncSequence(noop);
@@ -833,9 +833,9 @@ describe('switchMap', () => {
     const fn = jest.fn();
 
     sinks.forEach(fn)(
-      operators.switchMap((x: number) => {
-        return web.delay(5)(sources.fromArray([x, x * 2]));
-      })(source)
+      operators.switchMap((x: number) => (
+        operators.take(2)(operators.map((y: number) => x * (y + 1))(web.interval(5)))
+      ))(source)
     );
 
     jest.runAllTimers();

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -798,7 +798,7 @@ describe('skipWhile', () => {
 describe('switchMap', () => {
   const noop = operators.switchMap(x => sources.fromValue(x));
   passesPassivePull(noop);
-  // TODO: passesActivePush(noop);
+  passesActivePush(noop);
   passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);


### PR DESCRIPTION
All of the flattening map operators weren't respecting pulls on cold sources. More care needs to go into when a flattening map operator can pull on the source or on inner sources to prevent overflowing (infinite pulls from either inner sources or the outer source) or double pulling.