### PR TITLE
Fix sample operator pulling for cold sources

### DIFF
--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -646,13 +646,20 @@ describe('onStart', () => {
 });
 
 describe('sample', () => {
-  const noop = operators.sample(sources.fromValue(null));
-  // TODO: passesPassivePull(noop);
-  // TODO: passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
-  // TODO: passesSourceEnd(noop);
+  const valueThenNever: types.sourceT<any> = sink =>
+    sink(deriving.start(tb => {
+      if (tb === deriving.pull)
+        sink(deriving.push(null));
+    }));
+
+  const noop = operators.sample(valueThenNever);
+
+  passesPassivePull(noop);
+  passesActivePush(noop);
+  passesSinkClose(noop);
+  passesSourceEnd(noop);
   passesSingleStart(noop);
-  // TODO: passesStrictEnd(noop);
+  passesStrictEnd(noop);
 
   it('emits the latest value when a notifier source emits', () => {
     const { source: notifier$, next: notify } = sources.makeSubject();


### PR DESCRIPTION
The `sample` operator needs to be modified to respect cold source pulling and pull only when it runs out of values. Additionally it needs to pull from the notifier when new values come in from the source or when the notifier is activated, see #51   for a similar fix.

Lastly this also fixes the strict ending edge cases