### PR TITLE
Fix skipUntil pulling and add early closing

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -625,6 +625,9 @@ let skipUntil = (notifier: sourceT('a)): operatorT('b, 'b) =>
             | Push(_) =>
               state.skip = false;
               state.notifierTalkback(. Close);
+            | End when state.skip =>
+              state.ended = true;
+              state.sourceTalkback(. Close);
             | End => ()
             }
           );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -621,7 +621,9 @@ let skipUntil = (notifier: sourceT('a)): operatorT('b, 'b) =>
 
           notifier((. signal) =>
             switch (signal) {
-            | Start(innerTb) => state.notifierTalkback = innerTb
+            | Start(innerTb) =>
+              state.notifierTalkback = innerTb;
+              innerTb(. Pull);
             | Push(_) =>
               state.skip = false;
               state.notifierTalkback(. Close);
@@ -631,10 +633,7 @@ let skipUntil = (notifier: sourceT('a)): operatorT('b, 'b) =>
             | End => ()
             }
           );
-        | Push(_) when state.skip && !state.ended =>
-          state.pulled = false;
-          state.notifierTalkback(. Pull);
-        | Push(_) when !state.ended =>
+        | Push(_) when !state.skip && !state.ended =>
           state.pulled = false;
           sink(. signal);
         | Push(_) => ()

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -757,6 +757,7 @@ describe('skipUntil', () => {
   passesSourceEnd(noop);
   passesSingleStart(noop);
   passesAsyncSequence(noop);
+  passesStrictEnd(noop);
 
   it('skips values until the notifier source emits', () => {
     const { source: notifier$, next: notify } = sources.makeSubject();

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -752,7 +752,7 @@ describe('skip', () => {
 describe('skipUntil', () => {
   const noop = operators.skipUntil(sources.fromValue(null));
   passesPassivePull(noop);
-  // TODO: passesActivePush(noop);
+  passesActivePush(noop);
   passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -751,7 +751,7 @@ describe('skip', () => {
 
 describe('skipUntil', () => {
   const noop = operators.skipUntil(sources.fromValue(null));
-  // TODO: passesPassivePull(noop);
+  passesPassivePull(noop);
   // TODO: passesActivePush(noop);
   // TODO: passesSinkClose(noop);
   passesSourceEnd(noop);

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -753,7 +753,7 @@ describe('skipUntil', () => {
   const noop = operators.skipUntil(sources.fromValue(null));
   passesPassivePull(noop);
   // TODO: passesActivePush(noop);
-  // TODO: passesSinkClose(noop);
+  passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
   passesAsyncSequence(noop);


### PR DESCRIPTION
This is similar to #51 in that `skipUntil` wasn't pulling at consistent times. It's a little different, since the `notifier` in `skipUntil` must always be pulled first, before the `source`, since otherwise the notifier doesn't have a chance to emit a value and let `source` values flow through before `source` emits its own value.

Additionally the `skipUntil` operator now closes the `source` when it can never emit a value anymore, i.e. when the `notifier` ends without emitting any values.