### PR TITLE
Remove redundant Close/End guards from operators and add them to sources

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -382,8 +382,6 @@ let flatten = mergeAll;
 let onEnd = (f: (. unit) => unit): operatorT('a, 'a) =>
   curry(source =>
     curry(sink => {
-      let ended = ref(false);
-
       source((. signal) =>
         switch (signal) {
         | Start(talkback) =>
@@ -391,26 +389,19 @@ let onEnd = (f: (. unit) => unit): operatorT('a, 'a) =>
             Start(
               (. signal) => {
                 switch (signal) {
-                | Close when ! ended^ =>
-                  ended := true;
-                  f(.);
-                | Close
-                | Pull => ()
+                | Close => f(.)
+                | _ => ()
                 };
-
                 talkback(. signal);
               },
             ),
           )
         | End =>
-          if (! ended^) {
-            ended := true;
-            sink(. signal);
-            f(.);
-          }
+          sink(. signal);
+          f(.);
         | _ => sink(. signal)
         }
-      );
+      )
     })
   );
 

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -505,7 +505,6 @@ describe('map', () => {
   passesSinkClose(noop);
   passesSourceEnd(noop);
   passesSingleStart(noop);
-  // TODO: passesStrictEnd(noop);
   passesAsyncSequence(noop);
 
   it('maps over values given a transform function', () => {


### PR DESCRIPTION
This removes Close/End guards that prevent signals after closing/ending from operators that have non-idempotent effects or only deal with a single source and instead adds guardds to all sources to make this case less likely.