### PR TITLE
Fix operators that may stall when cold sources aren't receiving Pull signals

### DIFF
--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -264,12 +264,15 @@ let concatMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
                 state.innerPulled = true;
                 state.innerTalkback(. Pull);
               };
-            | Close when !state.ended =>
-              state.ended = true;
-              state.innerActive = false;
-              state.innerTalkback(. Close);
-              state.outerTalkback(. Close);
-            | Close => ()
+            | Close =>
+              if (!state.ended) {
+                state.ended = true;
+                state.outerTalkback(. Close);
+              };
+              if (state.innerActive) {
+                state.innerActive = false;
+                state.innerTalkback(. Close);
+              };
             },
         ),
       );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -376,8 +376,9 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         switch (signal) {
         | Start(tb) => state.outerTalkback = tb
         | Push(x) when !state.ended =>
-          state.outerPulled = false;
           applyInnerSource(f(. x));
+          state.outerPulled = true;
+          state.outerTalkback(. Pull);
         | Push(_) => ()
         | End when !state.ended =>
           state.ended = true;

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -376,9 +376,12 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         switch (signal) {
         | Start(tb) => state.outerTalkback = tb
         | Push(x) when !state.ended =>
+          state.outerPulled = false;
           applyInnerSource(f(. x));
-          state.outerPulled = true;
-          state.outerTalkback(. Pull);
+          if (!state.outerPulled) {
+            state.outerPulled = true;
+            state.outerTalkback(. Pull);
+          };
         | Push(_) => ()
         | End when !state.ended =>
           state.ended = true;
@@ -405,6 +408,8 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
               if (!state.outerPulled && !state.ended) {
                 state.outerPulled = true;
                 state.outerTalkback(. Pull);
+              } else {
+                state.outerPulled = false;
               };
 
               Rebel.Array.forEach(state.innerTalkbacks, tb => tb(. Pull));

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -836,12 +836,15 @@ let switchMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
                 state.innerPulled = true;
                 state.innerTalkback(. Pull);
               };
-            | Close when !state.ended =>
-              state.ended = true;
-              state.innerActive = false;
-              state.innerTalkback(. Close);
-              state.outerTalkback(. Close);
-            | Close => ()
+            | Close =>
+              if (!state.ended) {
+                state.ended = true;
+                state.outerTalkback(. Close);
+              };
+              if (state.innerActive) {
+                state.innerActive = false;
+                state.innerTalkback(. Close);
+              };
             },
         ),
       );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -504,7 +504,13 @@ let sample = (notifier: sourceT('a)): operatorT('b, 'b) =>
         | Start(tb) => state.sourceTalkback = tb
         | Push(x) =>
           state.value = Some(x);
-          state.notifierTalkback(. Pull);
+          if (!state.pulled) {
+            state.pulled = true;
+            state.notifierTalkback(. Pull);
+            state.sourceTalkback(. Pull);
+          } else {
+            state.pulled = false;
+          };
         | End when !state.ended =>
           state.ended = true;
           state.notifierTalkback(. Close);

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -697,7 +697,11 @@ let skipUntil = (notifier: sourceT('a)): operatorT('b, 'b) =>
         | Push(_) when !state.skip && !state.ended =>
           state.pulled = false;
           sink(. signal);
-        | Push(_) => ()
+        | Push(_) when !state.pulled =>
+          state.pulled = true;
+          state.sourceTalkback(. Pull);
+          state.notifierTalkback(. Pull);
+        | Push(_) => state.pulled = false
         | End =>
           if (state.skip) {
             state.notifierTalkback(. Close);

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -382,22 +382,22 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
       sink(.
         Start(
           (. signal) =>
-            if (!state.ended) {
-              switch (signal) {
-              | Close =>
-                let tbs = state.innerTalkbacks;
+            switch (signal) {
+            | Close =>
+              if (!state.ended) {
                 state.ended = true;
-                state.innerTalkbacks = Rebel.Array.makeEmpty();
                 state.outerTalkback(. signal);
-                Rebel.Array.forEach(tbs, tb => tb(. signal));
-              | Pull =>
-                if (!state.outerPulled) {
-                  state.outerPulled = true;
-                  state.outerTalkback(. Pull);
-                };
-
-                Rebel.Array.forEach(state.innerTalkbacks, tb => tb(. Pull));
               };
+
+              Rebel.Array.forEach(state.innerTalkbacks, tb => tb(. signal));
+              state.innerTalkbacks = Rebel.Array.makeEmpty();
+            | Pull =>
+              if (!state.outerPulled && !state.ended) {
+                state.outerPulled = true;
+                state.outerTalkback(. Pull);
+              };
+
+              Rebel.Array.forEach(state.innerTalkbacks, tb => tb(. Pull));
             },
         ),
       );

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -372,6 +372,9 @@ let mergeMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         | Push(x) when !state.ended =>
           state.outerPulled = false;
           applyInnerSource(f(. x));
+          if (!state.outerPulled) {
+            state.outerTalkback(. Pull);
+          };
         | Push(_) => ()
         | End when !state.ended =>
           state.ended = true;

--- a/src/wonka_operators.re
+++ b/src/wonka_operators.re
@@ -48,8 +48,13 @@ let buffer = (notifier: sourceT('a)): operatorT('b, array('b)) =>
           );
         | Push(value) when !state.ended =>
           Rebel.MutableQueue.add(state.buffer, value);
-          state.pulled = false;
-          state.notifierTalkback(. Pull);
+          if (!state.pulled) {
+            state.pulled = true;
+            state.sourceTalkback(. Pull);
+            state.notifierTalkback(. Pull);
+          } else {
+            state.pulled = false;
+          };
         | Push(_) => ()
         | End when !state.ended =>
           state.ended = true;

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -196,7 +196,7 @@ const passesSourcePushThenEnd = (
         expect(tb).not.toBe(deriving.close);
         if (tb === deriving.pull) {
           pulls++;
-          if (pulls === 1) { sink(deriving.push(0)); }
+          if (pulls <= 2) { sink(deriving.push(0)); }
           else { sink(deriving.end()); }
         }
       }));
@@ -218,8 +218,12 @@ const passesSourcePushThenEnd = (
     talkback(deriving.pull);
     jest.runAllTimers();
     expect(ending).toBe(1);
-    expect(signals).toEqual([deriving.push(result), deriving.end()]);
-    expect(pulls).toBe(2);
+    expect(pulls).toBe(3);
+    expect(signals).toEqual([
+      deriving.push(result),
+      deriving.push(result),
+      deriving.end()
+    ]);
   });
 
 /* This tests a noop operator for Start signals from the source.
@@ -423,7 +427,7 @@ describe('buffer', () => {
   passesPassivePull(noop, [0]);
   passesActivePush(noop, [0]);
   passesSinkClose(noop);
-  passesSourceEnd(noop, [0]);
+  passesSourcePushThenEnd(noop, [0]);
   passesSingleStart(noop);
   passesStrictEnd(noop);
 

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -1093,7 +1093,7 @@ describe('takeUntil', () => {
   passesPassivePull(noop);
   passesActivePush(noop);
   passesSinkClose(noop);
-  passesSourceEnd(noop);
+  passesSourcePushThenEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);
   passesAsyncSequence(noop);

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -99,14 +99,12 @@ const passesSinkClose = (operator: types.operatorT<any, any>) =>
   it('responds to Close signals from sink (spec)', () => {
     let talkback = null;
     let closing = 0;
-    let pulls = 0;
 
     const source: types.sourceT<any> = sink => {
       sink(deriving.start(tb => {
-        if (tb === deriving.pull) {
-          pulls++;
-          if (!closing) sink(deriving.push(0));
-        } if (tb === deriving.close) {
+        if (tb === deriving.pull && !closing) {
+          sink(deriving.push(0));
+        } else if (tb === deriving.close) {
           closing++;
         }
       }));
@@ -127,7 +125,6 @@ const passesSinkClose = (operator: types.operatorT<any, any>) =>
     talkback(deriving.pull);
     jest.runAllTimers();
     expect(closing).toBe(1);
-    expect(pulls).toBe(1);
   });
 
 /* This tests a noop operator for End signals from the source.
@@ -735,8 +732,8 @@ describe('mergeMap', () => {
     jest.runAllTimers();
     expect(fn.mock.calls).toEqual([
       [1],
-      [2],
       [10],
+      [2],
       [20],
     ]);
   });

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -457,6 +457,22 @@ describe('concatMap', () => {
     ]);
   });
 
+  it('works for fully asynchronous sources', () => {
+    const fn = jest.fn();
+
+    sinks.forEach(fn)(
+      operators.concatMap(() => {
+        return sources.make(observer => {
+          setTimeout(() => observer.next(1));
+          return () => {};
+        })
+      })(sources.fromValue(null))
+    );
+
+    jest.runAllTimers();
+    expect(fn).toHaveBeenCalledWith(1);
+  });
+
   it('emits synchronous values in order', () => {
     const values = [];
 

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -431,6 +431,28 @@ describe('concatMap', () => {
     ]);
   });
 
+  // This synchronous test for concatMap will behave the same as mergeMap & switchMap
+  it('lets inner sources finish when outer source ends', () => {
+    const values = [];
+    const teardown = jest.fn();
+    const fn = (signal: types.signalT<any>) => {
+      values.push(signal);
+      if (deriving.isStart(signal)) {
+        deriving.unboxStart(signal)(deriving.pull);
+        deriving.unboxStart(signal)(deriving.close);
+      }
+    };
+
+    operators.concatMap(() => {
+      return sources.make(() => teardown);
+    })(sources.fromValue(null))(fn);
+
+    expect(teardown).toHaveBeenCalled();
+    expect(values).toEqual([
+      deriving.start(expect.any(Function)),
+    ]);
+  });
+
   // This asynchronous test for concatMap will behave differently than mergeMap & switchMap
   it('emits values from each flattened asynchronous source, one at a time', () => {
     const source = web.delay<number>(4)(sources.fromArray([1, 10]));

--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -836,7 +836,7 @@ describe('sample', () => {
   passesPassivePull(noop);
   passesActivePush(noop);
   passesSinkClose(noop);
-  passesSourceEnd(noop);
+  passesSourcePushThenEnd(noop);
   passesSingleStart(noop);
   passesStrictEnd(noop);
 

--- a/src/wonka_sinks.test.ts
+++ b/src/wonka_sinks.test.ts
@@ -1,5 +1,6 @@
 import * as deriving from './helpers/wonka_deriving';
 import * as sinks from './wonka_sinks.gen';
+import * as sources from './wonka_sources.gen';
 import * as web from './web/wonkaJs.gen';
 import * as types from './wonka_types.gen';
 
@@ -198,6 +199,12 @@ describe('toPromise', () => {
 
     await promise;
     expect(fn).toHaveBeenCalledWith(1);
+  });
+
+  it('creates a Promise for synchronous sources', async () => {
+    const fn = jest.fn();
+    await web.toPromise(sources.fromArray([1, 2, 3])).then(fn);
+    expect(fn).toHaveBeenCalledWith(3);
   });
 });
 

--- a/src/wonka_sources.re
+++ b/src/wonka_sources.re
@@ -138,14 +138,12 @@ let empty = (sink: sinkT('a)): unit => {
       (. signal) => {
         switch (signal) {
         | Close => ended := true
+        | Pull when ! ended^ => sink(. End)
         | _ => ()
         }
       },
     ),
   );
-  if (! ended^) {
-    sink(. End);
-  };
 };
 
 [@genType]

--- a/src/wonka_sources.re
+++ b/src/wonka_sources.re
@@ -73,7 +73,6 @@ let make = (f: (. observerT('a)) => teardownT): sourceT('a) =>
           if (!state.ended) {
             state.ended = true;
             sink(. End);
-            state.teardown(.);
           },
       });
 

--- a/src/wonka_sources.test.ts
+++ b/src/wonka_sources.test.ts
@@ -1,5 +1,6 @@
 import * as deriving from './helpers/wonka_deriving';
 import * as sources from './wonka_sources.gen';
+import * as operators from './wonka_operators.gen';
 import * as types from './wonka_types.gen';
 import * as web from './web/wonkaJs.gen';
 
@@ -132,6 +133,29 @@ describe('fromValue', () => {
       deriving.start(expect.any(Function)),
       deriving.push(1),
       deriving.end()
+    ]);
+  });
+});
+
+describe('merge', () => {
+  const source = operators.merge<any>([
+    sources.fromValue(0),
+    sources.empty
+  ]);
+
+  passesColdPull(source);
+  passesActiveClose(source);
+
+  it('correctly merges two sources', () => {
+    const source = operators.merge<any>([
+      sources.fromValue(0),
+      sources.empty
+    ]);
+
+    expect(collectSignals(source)).toEqual([
+      deriving.start(expect.any(Function)),
+      deriving.push(0),
+      deriving.end(),
     ]);
   });
 });

--- a/src/wonka_sources.test.ts
+++ b/src/wonka_sources.test.ts
@@ -158,6 +158,24 @@ describe('merge', () => {
       deriving.end(),
     ]);
   });
+
+  it('correctly merges hot sources', () => {
+    const onStart = jest.fn();
+    const source = operators.merge<any>([
+      operators.onStart(onStart)(sources.never),
+      operators.onStart(onStart)(sources.never),
+      operators.onStart(onStart)(sources.fromArray([1, 2])),
+    ]);
+
+    const signals = collectSignals(source);
+    expect(onStart).toHaveBeenCalledTimes(3);
+
+    expect(signals).toEqual([
+      deriving.start(expect.any(Function)),
+      deriving.push(1),
+      deriving.push(2),
+    ]);
+  });
 });
 
 describe('concat', () => {

--- a/src/wonka_sources.test.ts
+++ b/src/wonka_sources.test.ts
@@ -146,8 +146,31 @@ describe('merge', () => {
   passesColdPull(source);
   passesActiveClose(source);
 
-  it('correctly merges two sources', () => {
+  it('correctly merges two sources where the second is empty', () => {
     const source = operators.merge<any>([
+      sources.fromValue(0),
+      sources.empty
+    ]);
+
+    expect(collectSignals(source)).toEqual([
+      deriving.start(expect.any(Function)),
+      deriving.push(0),
+      deriving.end(),
+    ]);
+  });
+});
+
+describe('concat', () => {
+  const source = operators.concat<any>([
+    sources.fromValue(0),
+    sources.empty
+  ]);
+
+  passesColdPull(source);
+  passesActiveClose(source);
+
+  it('correctly concats two sources where the second is empty', () => {
+    const source = operators.concat<any>([
       sources.fromValue(0),
       sources.empty
     ]);


### PR DESCRIPTION
Some operators _omit_ `Push` signals until an appropriate time to send them and also have inner sources that are being pulled at the same time.

This can cause a condition where cold sources aren't being pulled anymore as the sink is not receiving a value that it can react to with a `Pull` signal.