### PR TITLE
Add strict ending to onEnd and onPush

### DIFF
--- a/src/wonka_operators.test.ts
+++ b/src/wonka_operators.test.ts
@@ -758,6 +758,7 @@ describe('onEnd', () => {
   passesActivePush(noop);
   passesSinkClose(noop);
   passesSourceEnd(noop);
+  passesStrictEnd(noop);
   passesSingleStart(noop);
   passesAsyncSequence(noop);
 
@@ -781,6 +782,7 @@ describe('onPush', () => {
   passesActivePush(noop);
   passesSinkClose(noop);
   passesSourceEnd(noop);
+  passesStrictEnd(noop);
   passesSingleStart(noop);
   passesAsyncSequence(noop);
 


### PR DESCRIPTION
Since these are side-effects that may be used
to reinsert more signals into the source chain,
through subjects for instance, they need to
protect themselves from dangerous signal loops.