### PR TITLE
Fix switchMap and concatMap not forwarding Push before Start

### DIFF
--- a/src/Wonka_operators.re
+++ b/src/Wonka_operators.re
@@ -202,11 +202,11 @@ let concatMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         ended: false,
       };
 
-      let rec applyInnerSource = innerSource =>
+      let rec applyInnerSource = innerSource => {
+        state.innerActive = true;
         innerSource((. signal) =>
           switch (signal) {
           | Start(tb) =>
-            state.innerActive = true;
             state.innerTalkback = tb;
             state.innerPulled = false;
             tb(. Pull);
@@ -231,6 +231,7 @@ let concatMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
           | End => ()
           }
         );
+      };
 
       source((. signal) =>
         switch (signal) {
@@ -822,23 +823,22 @@ let switchMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
         ended: false,
       };
 
-      let applyInnerSource = innerSource =>
+      let applyInnerSource = innerSource => {
+        state.innerActive = true;
         innerSource((. signal) =>
           switch (signal) {
           | Start(tb) =>
-            state.innerActive = true;
             state.innerTalkback = tb;
             state.innerPulled = false;
             tb(. Pull);
-          | Push(_) when state.innerActive =>
+          | Push(_) =>
             sink(. signal);
             if (!state.innerPulled) {
               state.innerTalkback(. Pull);
             } else {
               state.innerPulled = false;
             };
-          | Push(_) => ()
-          | End when state.innerActive =>
+          | End =>
             state.innerActive = false;
             if (state.ended) {
               sink(. signal);
@@ -846,9 +846,9 @@ let switchMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
               state.outerPulled = true;
               state.outerTalkback(. Pull);
             };
-          | End => ()
           }
         );
+      };
 
       source((. signal) =>
         switch (signal) {

--- a/src/Wonka_operators.re
+++ b/src/Wonka_operators.re
@@ -826,25 +826,27 @@ let switchMap = (f: (. 'a) => sourceT('b)): operatorT('a, 'b) =>
       let applyInnerSource = innerSource => {
         state.innerActive = true;
         innerSource((. signal) =>
-          switch (signal) {
-          | Start(tb) =>
-            state.innerTalkback = tb;
-            state.innerPulled = false;
-            tb(. Pull);
-          | Push(_) =>
-            sink(. signal);
-            if (!state.innerPulled) {
-              state.innerTalkback(. Pull);
-            } else {
+          if (state.innerActive) {
+            switch (signal) {
+            | Start(tb) =>
+              state.innerTalkback = tb;
               state.innerPulled = false;
-            };
-          | End =>
-            state.innerActive = false;
-            if (state.ended) {
+              tb(. Pull);
+            | Push(_) =>
               sink(. signal);
-            } else if (!state.outerPulled) {
-              state.outerPulled = true;
-              state.outerTalkback(. Pull);
+              if (!state.innerPulled) {
+                state.innerTalkback(. Pull);
+              } else {
+                state.innerPulled = false;
+              };
+            | End =>
+              state.innerActive = false;
+              if (state.ended) {
+                sink(. signal);
+              } else if (!state.outerPulled) {
+                state.outerPulled = true;
+                state.outerTalkback(. Pull);
+              };
             };
           }
         );


### PR DESCRIPTION
This is technically incorrect, but a lot of asynchronous
sources will Push eagerly, which means Start doesn't
always get to talk first.