### PR TITLE
Fix fromDomEvent example so compiles.

### DIFF
--- a/docs/api/sources.md
+++ b/docs/api/sources.md
@@ -141,7 +141,7 @@ on the source whenever the DOM emits them on the passed element.
 > when compiling natively.
 
 ```reason
-open WebApi.Dom;
+open Webapi.Dom;
 open Document;
 
 let element = getElementById("root", document);

--- a/docs/api/sources.md
+++ b/docs/api/sources.md
@@ -144,7 +144,7 @@ on the source whenever the DOM emits them on the passed element.
 open Webapi.Dom;
 open Document;
 
-let element = getElementById("root", document);
+let element = getElementById("root", document)->Belt.Option.getExn;
 
 Wonka.fromDomEvent(element, "click")
   |> Wonka.subscribe((. click) => Js.log(click));


### PR DESCRIPTION
Fix fromDomEvent example so compiles.
```ocaml
  This has type:
    option(Dom.element)
  But somewhere wanted:
    Dom.element (defined as
      Dom.eventTarget_like(Dom._node(Dom._element(Dom._baseClass))))
```