### PR TITLE
Update package.json to support webpack@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "source": "./src/Wonka.ts"
     },
     "./package.json": "./package.json",
-    "./lib/": "./lib/"
+    "./": "./"
   },
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "source": "./src/Wonka.ts"
     },
     "./package.json": "./package.json",
-    "./lib/es6/src/": "./lib/es6/src/"
+    "./lib/": "./lib/"
   },
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "types": "./dist/types/src/Wonka.d.ts",
       "source": "./src/Wonka.ts"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./lib/es6/src/": "./lib/es6/src/"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
In webpack@5, `exports` field is supported so an extra export is needed for rescript user to consume this lib